### PR TITLE
Fix displayName inconsistency

### DIFF
--- a/index.cjsx
+++ b/index.cjsx
@@ -107,7 +107,7 @@ emptyDetail =
 
 module.exports =
   name: 'Senka Calc'
-  displayName: <span><FontAwesome key={0} name='child' style={fontSize: 16, width: 17} /> {__ 'Senka Calc'}</span>
+  displayName: <span><FontAwesome key={0} name='child' /> {__ 'Senka Calc'}</span>
   priority: 7
   author: 'Rui'
   link: 'https://github.com/ruiii'


### PR DESCRIPTION
This inline style of displayName causes inconsistency as shown below.

Good case
![image](https://cloud.githubusercontent.com/assets/1596656/12708573/6a97e82c-c866-11e5-877d-e4c270497d1e.png)

Bad case. Notice the incontinuous of border on the leftmost part
![image](https://cloud.githubusercontent.com/assets/1596656/12708578/72af5f36-c866-11e5-98a9-fd90d16c7fd2.png)
